### PR TITLE
support provider aliasing

### DIFF
--- a/core/terraform-options.nix
+++ b/core/terraform-options.nix
@@ -44,7 +44,7 @@ with lib;
       '';
     };
     provider = mkOption {
-      type = with types; attrsOf attrs;
+      type = with types; attrsOf (oneOf [ attrs (listOf attrs) ]);
       default = {};
       description = ''
         provider, basically an API


### PR DESCRIPTION
i need [provider aliasing][1]

example config:
```nix
provider.docker = [
  {
    alias = "local";
    host = "unix:///run/docker.sock";
  }
];
```

[1]: https://www.terraform.io/docs/configuration/providers.html#alias-multiple-provider-instances