### PR TITLE
Add ability to override packages as input parameter and command line flag

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+- add `--pkgs` option to commands to allow overriding/pinning nixpkgs on the command line
+- add `pkgs` parameter to `core/default.nix` to allow pinning packages when calling `core/` directly from Nix.
 
 ## [2.2.3] - 2020-04-22
 

--- a/core/default.nix
+++ b/core/default.nix
@@ -1,10 +1,8 @@
 # terranix core
 # -------------
-{ terranix_config, strip_nulls ? true }:
+{ pkgs ? import <nixpkgs> { }; terranix_config, strip_nulls ? true }:
 
-let pkgs = import <nixpkgs> { };
-
-in with pkgs;
+with pkgs;
 with pkgs.lib;
 with builtins;
 


### PR DESCRIPTION
This adds the ability to pass a `pkgs` parameter (still defaulted to `import <nixpkgs> { }` so no functionality changes without passing it) when calling `core/default.nix`.

It also adds `--pkgs` flags to `terranix`, `terranix-doc-json`, and `terranix-doc-man`, which can be used to specify a path that nixpkgs can be imported from. The path can be a nix expression, for instance `(import nix/sources.nix).nixpkgs` to use nixpkgs pinned with [Niv](https://github.com/nmattia/niv#README).

The intent of these changes are:

* To allow easy pinning of the nixpkgs used by the Terranix scripts (e.g. by using a wrapper that passes the `--pkgs` flag)
* To allow direct import of `core/default.nix` into external nix code without introducing an unpinned nixpkgs dependency.